### PR TITLE
Fixes /send Request type

### DIFF
--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -89,19 +89,24 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              minItems: 1
-              items:
-                $ref: '#/components/schemas/command'
+              required: [cmds]
+              properties:
+                cmds:
+                  type: array
+                  minItems: 1
+                  items:
+                    $ref: '#/components/schemas/command'
       responses:
         "200":
           content:
             application/json:
               schema:
+                required: [requestKeys]
                 properties:
                   requestKeys:
                     description: Request keys for use with `poll` or `listen` to retrieve results.
                     type: array
+                    minItems: 1
                     items:
                       $ref: '#/components/schemas/request-key'
         "400":


### PR DESCRIPTION
The Request type for the `/send` endpoint was being defined as an array of `Command`, but it should be an object with a `cmds` field.

See the `/send` specifications defined at: 
https://github.com/kadena-io/pact/blob/master/src-ghc/Pact/Server/ApiServer.hs#L97

It expects the [SubmitBatch](https://github.com/kadena-io/pact/blob/master/src/Pact/Types/API.hs#L54) type as the request, and [RequestKeys](https://github.com/kadena-io/pact/blob/master/src/Pact/Types/API.hs#L43) type as response.

Other small fixes:
- Makes `requestKeys` in Response a required field.
- Makes `cmds` in Request a require field.
- Makes `requestKeys` array non-empty.