### PR TITLE
Local preflight response example

### DIFF
--- a/chainweb.openapi.yaml
+++ b/chainweb.openapi.yaml
@@ -13,7 +13,6 @@ info:
     conservative extension of Bitcoin's Nakamoto consensus that extends
     Bitcoin's single chain algorithm to multiple chains. This allows for
     unlimited transaction throughput by horizontally scaling the number of chains.
-    For
 
     Feedback and bug reports for the content of this site are welcome. Please
     open an issue at [this github repository](https://github.com/kadena-io/chainweb-openapi/issues).

--- a/chainweb.openapi.yaml
+++ b/chainweb.openapi.yaml
@@ -13,6 +13,7 @@ info:
     conservative extension of Bitcoin's Nakamoto consensus that extends
     Bitcoin's single chain algorithm to multiple chains. This allows for
     unlimited transaction throughput by horizontally scaling the number of chains.
+    For
 
     Feedback and bug reports for the content of this site are welcome. Please
     open an issue at [this github repository](https://github.com/kadena-io/chainweb-openapi/issues).
@@ -174,7 +175,7 @@ tags:
     For only querying blocks that are included in the winning branch of the
     chain the `branch` endpoints can be used, which return blocks in descending
     order starting from the leafs of branches of the block chain.
-    
+
     Block headers are returned in three different formats specified in the `accept` header of the request:
     *   `application/json`, returns block headers in base64Url (without padding)
         encoded binary.

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -13,6 +13,7 @@ info:
     url: 'https://i.imgur.com/bAZFAGF.png'
     # backgroundColor: '#0033A0'
     alttext: Kadena Chainweb Logo
+    href: 'https://api.chainweb.com/openapi'
 
 # ############################################################################ #
 # Servers
@@ -99,7 +100,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/command-result'
+                oneOf:
+                  - $ref: '#/components/schemas/command-result'
+                  - $ref: '#/components/schemas/preflight-result'
         "400":
           description: The command was invalid.
           content:
@@ -481,6 +484,26 @@ components:
     # ######################################################################## #
     # Command Result and related
 
+    preflight-result:
+      title: Preflight /local result
+      tags: [model-preflight-result]
+      example:
+        $ref: '#/components/examples/preflight-result'
+      description:
+        The result of attempting to execute preflight simulation for a
+        single well-formed Pact command.
+      type: object
+      required: [preflightResult]
+      properties:
+        preflightResult:
+          $ref: '#/components/schemas/command-result'
+        preflightWarnings:
+          description:
+            A list of warnings associated with deprecated features in upcoming pact releases.
+          type: array
+          items:
+            type: string
+
     command-result:
       title: Command Result
       tags: [model-command-result]
@@ -826,6 +849,29 @@ components:
 
   examples:
 
+    preflight-result:
+      {
+        "preflightResult": { "gas":123,
+          "result": {
+            "status":"success",
+            "data":3
+            },
+          "reqKey":"cQ-guhschk0wTvMBtrqc92M7iYm4S2MYhipQ2vNKxoI",
+          "logs":"wsATyGqckuIvlm89hhd2j4t6RMkCrcwJe_oeCYr7Th8",
+          "metaData":null,
+          "continuation":null,
+          "txId":"456",
+          "events": [ {
+            "name": "TRANSFER",
+            "params": ["Alice", "Bob", 10.0],
+            "module": "coin",
+            "moduleHash": "ut_J_ZNkoyaPUEJhiwVeWnkSQn9JT9sQCWKdjjVVrWo"
+            } ]
+        },
+        "preflightWarnings": [
+          "Warning: Using deprecated native +: decimal/integer operator overload is deprecated"
+        ]
+      }
     command:
       { "hash": "H6XjdPHzMai2HLa3_yVkXfkFYMgA0bGfsB0kOsHAMuI",
         "sigs": [

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -99,9 +99,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/command-result'
-                  - $ref: '#/components/schemas/preflight-result'
+                $ref: '#/components/schemas/command-result'
         "400":
           description: The command was invalid.
           content:
@@ -482,25 +480,6 @@ components:
 
     # ######################################################################## #
     # Command Result and related
-
-    preflight-result:
-      title: Preflight result
-      tags: [model-preflight-result]
-      example:
-        $ref: '#/components/examples/preflight-result'
-      description:
-        The result of attempting to execute a single well-formed Pact /local preflight command.
-      type: object
-      required: [preflightWarnings,preflightResult]
-      properties:
-        preflightWarnings:
-          type: array
-          description:
-            A set of deprecation warnings generated as the result of pact command execution.
-          items:
-            type: string
-        preflightResult:
-          $ref: '#/components/schemas/command-result'
 
     command-result:
       title: Command Result

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -493,7 +493,7 @@ components:
         The result of attempting to execute preflight simulation for a
         single well-formed Pact command.
       type: object
-      required: [preflightResult]
+      required: [preflightResult,preflightWarnings]
       properties:
         preflightResult:
           $ref: '#/components/schemas/command-result'


### PR DESCRIPTION
This PR also adds a clickable home link via the logo to go back to `api.chainweb.com/openapi`. CC @EnoF 

![image](https://github.com/kadena-io/chainweb-openapi/assets/10459342/a6e6a8e1-86a0-499d-b5c3-5553086a98ff)
