### PR TITLE
Update openapi docs for module references

### DIFF
--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -701,10 +701,36 @@ components:
       - title: Module Reference
         description: Special pact value to directly reference a module or interface.
         type: object
+        required: [refName,refSpec]
+        example:
+          $ref: '#/components/examples/module_reference'
         properties:
           refName:
-            type: string
-            description: "Fully-qualified module or interface name."
+            type: object
+            required: [name,namespace]
+            description: The module name
+            properties:
+              name:
+                type: string
+                description: Bare name of a module
+              namespace:
+                type: string
+                nullable: true
+                description: Namespace of the indicated module
+          refSpec:
+            type: array
+            description: The module names to substitute for any references present in the module code
+            items:
+              type: object
+              required: [name,namespace]
+              properties:
+                name:
+                  type: string
+                  description: Bare name of a module
+                namespace:
+                  type: string
+                  nullable: true
+                  description: Namespace of the indicated module
       - title: Guard
         description: Special pact value for guard types.
         type: object
@@ -909,6 +935,19 @@ components:
         "nonce": "nonce-value"
       }
 
+    module_reference:
+      { 
+        "refName": {
+          "namespace": null,
+          "name": "coin"
+        },
+        "refSpec": [
+            {
+              "namespace": null,
+              "name": "fungible-v2"
+            }
+        ]
+      }
 
 
 # ############################################################################ #


### PR DESCRIPTION
The Chainweb OpenAPI specification for module references stats that it should be formatted in JSON as an object with one field (`refName`), ie.

```json
{
  "refName": "coin"
}
```

However, this disagrees with the JSON parsing and printing described in `PactValue`, and people on Discord have noticed that this documentation is incorrect. See:
https://github.com/kadena-io/pact/blob/20ce37f6e80da28c24f6fbfefcd2e3cfc3993b28/src/Pact/Types/PactValue.hs#L67-L87

A correct example would look like this:

```json
{
  "refName": {
    "namespace": null,
    "name": "coin",
  },
  "refSpec": [
    {
      "namespace": null,
      "name": "fungible-v2"
    }
  ]
}
```

This PR fixes the Open API spec for module references as pact values.

### More Details

How do we know the example is wrong? We can look at the JSON encoding / decoding instances.

`PModRef` is parsed with either `parseNoInfo` or the default `FromJSON` instance for `ModRef`:
https://github.com/kadena-io/pact/blob/20ce37f6e80da28c24f6fbfefcd2e3cfc3993b28/src/Pact/Types/Term/Internal.hs#L614

The `parseNoInfo` is a mirror for the encoding for module references, which similarly has an explicit function for dealing with no info field, `modRefKeyValues_`:
https://github.com/kadena-io/pact/blob/20ce37f6e80da28c24f6fbfefcd2e3cfc3993b28/src/Pact/Types/Term/Internal.hs#L628-L636

As far as the default instance goes, from what I can tell, the use of `lensyParseJSON 4` will drop the first four characters of the field names in the data type defined here:
https://github.com/kadena-io/pact/blob/20ce37f6e80da28c24f6fbfefcd2e3cfc3993b28/src/Pact/Types/Term/Internal.hs#L593-L600

ie. the default `FromJSON` will require that `refName :: ModuleName`, `refSpec :: Maybe [ModuleName])`, and `refInfo :: Info` are all present. Regardless of which encoding / decoding pair is used, it's clear that sending a module reference as a `PactValue` encoded in JSON will at _least_ require the fields `refName` and `refSpec`.

Then, `ModuleName` is not encoded / decoded as as string. It's an object in its own right:
https://github.com/kadena-io/pact/blob/20ce37f6e80da28c24f6fbfefcd2e3cfc3993b28/src/Pact/Types/Names.hs#L79-L82

With an instance to match:
https://github.com/kadena-io/pact/blob/20ce37f6e80da28c24f6fbfefcd2e3cfc3993b28/src/Pact/Types/Names.hs#L124C1-L131C64

### Open Questions

1. It is not obvious to me how `refInfo` should be treated in the documentation. It's not obvious to me whether it is supposed to be omitted from the request/response or if it's expected to be there at least some of the time. In the former case I can just omit the field from the docs. This is what I've done in the PR. In the latter case I can instead change the docs to specify this as a `oneOf` and describe both cases — with and without the `refInfo` field.

2. I've struggled to get the Docker build to show a preview of these docs without caching; I always see the state of the Pact spec at the very first change I made, rather than the most recent. I ended up copy/pasting the spec into a different tool so I could preview it and I think everything works, but I haven't actually previewed the docs using the Docker setup in this repo. Any advice on this is welcome!