### PR TITLE
Add webauthn signatures to the openapi spec

### DIFF
--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -351,7 +351,7 @@ components:
                   - type: string
                     contentEncoding: base16
                     description: |
-                      Base16-encoded cryptograhic signature of `cmd` field data
+                      Base16-encoded Ed25519 signature of `hash` field
                       for corresponding signer in payload.
                     example:
                       "8d452109cc0439234c093b5e204a7428bc0a54f22704402492e027aaa9375a34c910d8a468a12746d0d29e9353f4a3fbebe920d63bcc7963853995db015d060f"

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -355,10 +355,11 @@ components:
                       for corresponding signer in payload.
                     example:
                       "8d452109cc0439234c093b5e204a7428bc0a54f22704402492e027aaa9375a34c910d8a468a12746d0d29e9353f4a3fbebe920d63bcc7963853995db015d060f"
-                  - $ref: '#/components/schemas/webauthn-sig-string-2'
+                  - $ref: '#/components/schemas/webauthn-sig-string'
 
     webauthn-sig-string:
       type: string
+      contentMediaType: application/json
       description: |
         Stringified JSON WebAuthn signature object.
         The fields should be taken from the `response` field of a WebAuthn. credential response.
@@ -366,81 +367,11 @@ components:
         ```
         const r = await navigator.credentials.get();
         JSON.stringify({
-          authenticatorData: base64url_to_base64(r.response.authenticator_data),
-          cliendDataJSON: r.response.clientDataJSON,
-          signature: base64url_to_base64(r.response.signature)
+          "authenticatorData": base64url_to_base64(r.response.authenticator_data),
+          "clientDataJSON": r.response.clientDataJSON,
+          "signature": base64url_to_base64(r.response.signature)
         })
         ```
-      contentMediaType: application/json
-      jsonSchema:
-        $ref: '#/components/schemas/webauthn-sig'
-    webauthn-sig:
-      type: object
-      required:
-        - authenticatorData
-        - clientDataJSON
-        - signature
-      properties:
-        authenticatorData:
-          type: string
-          contentEncoding: base64
-          description: |
-            The `.response.authenticatorData` field, transcribed from base64Url to base64,
-            resulting from of calling `navigator.credentials.get()`.
-          example:
-            "+cNxurbmvuKrkAKBTgIRX89NPS7FT5KydvqIN951zwoBAAAADQ=="
-        clientDataJSON:
-          type: string
-          contentEncoding: base64Url
-          description: |
-            The `.response.signature` field resulting from of calling
-            `navigator.credentials.get()`.
-          example:
-            "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTkFDbG5makJiT2o3R2ZuRTg2YzJOZVZHaTBZUkRKcllidUF0cmhFUzJiYyIsIm9yaWdpbiI6Imh0dHBzOi8vZ3JlZy10ZXN0aW5nLTIwMjMtMDItMDcuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
-        signature:
-          type: string
-          contentEncoding: base64
-          description: |
-            The `.response.clientDataJSON` field, transcribed from base64Url to base64,
-            resulting from of calling `navigator.credentials.get()`.
-          example:
-            "MEYCIQDwQF19+Wjxs0boANssWEKoUFKhwHgiaycIeU5kRlY+RwIhAIAfCOUDVHr5aCrVQ1pbvCEw1xkeF0s4yjD48sDe9uO7"
-
-
-    webauthn-sig-string2:
-      type: string
-      contentMediaType: application/json
-      contentSchema:
-        type: object
-        required:
-          - authenticatorData
-          - clientDataJSON
-          - signature
-        properties:
-          authenticatorData:
-            type: string
-            contentEncoding: base64
-            description: |
-              The `.response.authenticatorData` field, transcribed from base64Url to base64,
-              resulting from of calling `navigator.credentials.get()`.
-            example:
-              "+cNxurbmvuKrkAKBTgIRX89NPS7FT5KydvqIN951zwoBAAAADQ=="
-          clientDataJSON:
-            type: string
-            contentEncoding: base64Url
-            description: |
-              The `.response.signature` field resulting from of calling
-              `navigator.credentials.get()`.
-            example:
-              "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTkFDbG5makJiT2o3R2ZuRTg2YzJOZVZHaTBZUkRKcllidUF0cmhFUzJiYyIsIm9yaWdpbiI6Imh0dHBzOi8vZ3JlZy10ZXN0aW5nLTIwMjMtMDItMDcuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
-          signature:
-            type: string
-            contentEncoding: base64
-            description: |
-              The `.response.clientDataJSON` field, transcribed from base64Url to base64,
-              resulting from of calling `navigator.credentials.get()`.
-            example:
-              "MEYCIQDwQF19+Wjxs0boANssWEKoUFKhwHgiaycIeU5kRlY+RwIhAIAfCOUDVHr5aCrVQ1pbvCEw1xkeF0s4yjD48sDe9uO7"
 
 
     payload:

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -347,13 +347,100 @@ components:
           items:
             properties:
               sig:
-                type: string
-                contentEncoding: base16
-                description: |
-                  Base16-encoded cryptograhic signature of `cmd` field data
-                  for corresponding signer in payload.
-                example:
-                  "8d452109cc0439234c093b5e204a7428bc0a54f22704402492e027aaa9375a34c910d8a468a12746d0d29e9353f4a3fbebe920d63bcc7963853995db015d060f"
+                anyOf:
+                  - type: string
+                    contentEncoding: base16
+                    description: |
+                      Base16-encoded cryptograhic signature of `cmd` field data
+                      for corresponding signer in payload.
+                    example:
+                      "8d452109cc0439234c093b5e204a7428bc0a54f22704402492e027aaa9375a34c910d8a468a12746d0d29e9353f4a3fbebe920d63bcc7963853995db015d060f"
+                  - $ref: '#/components/schemas/webauthn-sig-string-2'
+
+    webauthn-sig-string:
+      type: string
+      description: |
+        Stringified JSON WebAuthn signature object.
+        The fields should be taken from the `response` field of a WebAuthn. credential response.
+        For example, to construct a WebAuthn signature string in the browser:
+        ```
+        const r = await navigator.credentials.get();
+        JSON.stringify({
+          authenticatorData: base64url_to_base64(r.response.authenticator_data),
+          cliendDataJSON: r.response.clientDataJSON,
+          signature: base64url_to_base64(r.response.signature)
+        })
+        ```
+      contentMediaType: application/json
+      jsonSchema:
+        $ref: '#/components/schemas/webauthn-sig'
+    webauthn-sig:
+      type: object
+      required:
+        - authenticatorData
+        - clientDataJSON
+        - signature
+      properties:
+        authenticatorData:
+          type: string
+          contentEncoding: base64
+          description: |
+            The `.response.authenticatorData` field, transcribed from base64Url to base64,
+            resulting from of calling `navigator.credentials.get()`.
+          example:
+            "+cNxurbmvuKrkAKBTgIRX89NPS7FT5KydvqIN951zwoBAAAADQ=="
+        clientDataJSON:
+          type: string
+          contentEncoding: base64Url
+          description: |
+            The `.response.signature` field resulting from of calling
+            `navigator.credentials.get()`.
+          example:
+            "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTkFDbG5makJiT2o3R2ZuRTg2YzJOZVZHaTBZUkRKcllidUF0cmhFUzJiYyIsIm9yaWdpbiI6Imh0dHBzOi8vZ3JlZy10ZXN0aW5nLTIwMjMtMDItMDcuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
+        signature:
+          type: string
+          contentEncoding: base64
+          description: |
+            The `.response.clientDataJSON` field, transcribed from base64Url to base64,
+            resulting from of calling `navigator.credentials.get()`.
+          example:
+            "MEYCIQDwQF19+Wjxs0boANssWEKoUFKhwHgiaycIeU5kRlY+RwIhAIAfCOUDVHr5aCrVQ1pbvCEw1xkeF0s4yjD48sDe9uO7"
+
+
+    webauthn-sig-string2:
+      type: string
+      contentMediaType: application/json
+      contentSchema:
+        type: object
+        required:
+          - authenticatorData
+          - clientDataJSON
+          - signature
+        properties:
+          authenticatorData:
+            type: string
+            contentEncoding: base64
+            description: |
+              The `.response.authenticatorData` field, transcribed from base64Url to base64,
+              resulting from of calling `navigator.credentials.get()`.
+            example:
+              "+cNxurbmvuKrkAKBTgIRX89NPS7FT5KydvqIN951zwoBAAAADQ=="
+          clientDataJSON:
+            type: string
+            contentEncoding: base64Url
+            description: |
+              The `.response.signature` field resulting from of calling
+              `navigator.credentials.get()`.
+            example:
+              "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTkFDbG5makJiT2o3R2ZuRTg2YzJOZVZHaTBZUkRKcllidUF0cmhFUzJiYyIsIm9yaWdpbiI6Imh0dHBzOi8vZ3JlZy10ZXN0aW5nLTIwMjMtMDItMDcuZ2l0aHViLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
+          signature:
+            type: string
+            contentEncoding: base64
+            description: |
+              The `.response.clientDataJSON` field, transcribed from base64Url to base64,
+              resulting from of calling `navigator.credentials.get()`.
+            example:
+              "MEYCIQDwQF19+Wjxs0boANssWEKoUFKhwHgiaycIeU5kRlY+RwIhAIAfCOUDVHr5aCrVQ1pbvCEw1xkeF0s4yjD48sDe9uO7"
 
 
     payload:

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -362,14 +362,22 @@ components:
       contentMediaType: application/json
       description: |
         Stringified JSON WebAuthn signature object.
-        The fields should be taken from the `response` field of a WebAuthn. credential response.
-        For example, to construct a WebAuthn signature string in the browser:
+
+        For a WebAuthn signature string to be valid, it must correspond to
+        a `Signer` with `scheme: WebAuthn`.
+
+        The fields should be taken from the `response` field of a WebAuthn
+        `CredentialResponse`. For example, to construct a WebAuthn signature
+        string in the browser:
+
         ```
-        const r = await navigator.credentials.get();
+        const resp = await navigator.credentials.get();
+        const auth = r.response.authenticator_data;
+        const sig = r.response.signature;
         JSON.stringify({
-          "authenticatorData": base64url_to_base64(r.response.authenticator_data),
+          "authenticatorData": base64url_to_base64(auth),
           "clientDataJSON": r.response.clientDataJSON,
-          "signature": base64url_to_base64(r.response.signature)
+          "signature": base64url_to_base64(sig)
         })
         ```
 
@@ -471,8 +479,10 @@ components:
                 description: "Address, if any. Pact default expects this to match pubKey."
               scheme:
                 type: string
-                description: "Signer scheme. Default is ED25519."
-                enum: [ED25519,ETH]
+                description: |
+                  Signer scheme. Default is ED25519. When the Signer is `WebAuthn`, the
+                  corresponding `sig` must be a webauthn signature string.
+                enum: [ED25519,WebAuthn]
               clist:
                 description: List of capabilities associated with/installed by this signer.
                 properties:

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -363,20 +363,22 @@ components:
       description: |
         Stringified JSON WebAuthn signature object.
 
-        For a WebAuthn signature string to be valid, it must correspond to
-        a `Signer` with `scheme: WebAuthn`.
+        For a WebAuthn signature string to be valid, its corresponding `Signer`
+        must have `scheme: "WebAuthn"`.
 
-        The fields should be taken from the `response` field of a WebAuthn
+        The schema of a Pact WebAuthn signature object resembles that of
+        the WebAuthn standard `CredentialResponse`.
+        Its fields can be computed from the `response` field of a WebAuthn
         `CredentialResponse`. For example, to construct a WebAuthn signature
         string in the browser:
 
         ```
         const resp = await navigator.credentials.get();
-        const auth = r.response.authenticatorData();
-        const sig = r.response.signature;
+        const auth = resp.response.authenticatorData();
+        const sig = resp.response.signature;
         JSON.stringify({
           authenticatorData: base64url_to_base64(auth),
-          clientDataJSON: r.response.clientDataJSON,
+          clientDataJSON: resp.response.clientDataJSON,
           signature: base64url_to_base64(sig)
         })
         ```

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -480,8 +480,9 @@ components:
               scheme:
                 type: string
                 description: |
-                  Signer scheme. Default is ED25519. When the Signer is `WebAuthn`, the
-                  corresponding `sig` must be a webauthn signature string.
+                  Signer scheme. Default is ED25519. When the Signer is
+                  `WebAuthn`, the corresponding `sig` must be a WebAuthn
+                  signature string.
                 enum: [ED25519,WebAuthn]
               clist:
                 description: List of capabilities associated with/installed by this signer.

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -359,7 +359,7 @@ components:
 
     webauthn-sig-string:
       type: string
-      contentMediaType: application/json
+      # contentMediaType: application/json
       description: |
         Stringified JSON WebAuthn signature object.
 

--- a/pact.openapi.yaml
+++ b/pact.openapi.yaml
@@ -372,12 +372,12 @@ components:
 
         ```
         const resp = await navigator.credentials.get();
-        const auth = r.response.authenticator_data;
+        const auth = r.response.authenticatorData();
         const sig = r.response.signature;
         JSON.stringify({
-          "authenticatorData": base64url_to_base64(auth),
-          "clientDataJSON": r.response.clientDataJSON,
-          "signature": base64url_to_base64(sig)
+          authenticatorData: base64url_to_base64(auth),
+          clientDataJSON: r.response.clientDataJSON,
+          signature: base64url_to_base64(sig)
         })
         ```
 


### PR DESCRIPTION
Update the pact API spec to reflect the new `scheme` variant (`WebAuthn`) and its new signature format.

![image](https://github.com/kadena-io/chainweb-openapi/assets/993484/806e9bc7-91a4-4b35-ac63-caba69f08590)
